### PR TITLE
Automated Changelog Entry for 0.2.1 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,30 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.2.1
+
+([Full Changelog](https://github.com/jtpio/jupyterlab-plugin-graph/compare/0.2.0...05bc2f09694d089dd42f5cc43344ec91b5276646))
+
+### Maintenance and upkeep improvements
+
+- Update dependencies, switch to `jupyter-packaging` 0.10, adopt the releaser [#18](https://github.com/jtpio/jupyterlab-plugin-graph/pull/18) ([@jtpio](https://github.com/jtpio))
+
+### Other merged PRs
+
+- Bump ssri from 8.0.0 to 8.0.1 [#8](https://github.com/jtpio/jupyterlab-plugin-graph/pull/8) ([@dependabot](https://github.com/dependabot))
+- Bump ini from 1.3.5 to 1.3.8 [#7](https://github.com/jtpio/jupyterlab-plugin-graph/pull/7) ([@dependabot](https://github.com/dependabot))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jtpio/jupyterlab-plugin-graph/graphs/contributors?from=2020-11-09&to=2021-09-20&type=c))
+
+[@dependabot](https://github.com/search?q=repo%3Ajtpio%2Fjupyterlab-plugin-graph+involves%3Adependabot+updated%3A2020-11-09..2021-09-20&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajtpio%2Fjupyterlab-plugin-graph+involves%3Ajtpio+updated%3A2020-11-09..2021-09-20&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.2.0
 
 ### Changes
 
 - Support for JupyterLab 3.0
 - Adopt the new distribution system
-
-<!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.2.1 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jtpio/jupyterlab-plugin-graph  |
| Branch  | main  |
| Version Spec | 0.2.1 |
| Since | 0.2.0 |